### PR TITLE
Don't overwrite the pattern variable or you'll end up carrying around parts of objects you may not mean to.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ internals.action = function (server) {
             }
 
             if (additions) {
-                pattern = Hoek.applyToDefaults(pattern, typeof additions === 'string' ? Jsonic(additions) : additions);
+                return server.seneca.act(Hoek.applyToDefaults(pattern, typeof additions === 'string' ? Jsonic(additions) : additions), callback);
             }
 
             return server.seneca.act(pattern, callback);


### PR DESCRIPTION
The pattern variable will change to include items that are passed in as seneca parameters. It's probably not what you want.
