### PR TITLE
Set request so that the payload/query and other attributes are accessible in the seneca action

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,9 @@ exports.register = function (server, options, next) {
         'log': 'silent',
         'actcache': {
             'active': false
+        },
+        'default_plugins': {
+            'web' : false
         }
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,7 +131,7 @@ internals.request = function (seneca) {
     return (request) => {
 
         return seneca.delegate({
-            req$: request.raw.req,
+            req$: request,
             res$: request.raw.res,
             tx$:  seneca.root.idgen()
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,11 +23,15 @@ exports.register = function (server, options, next) {
         'log': 'silent',
         'actcache': {
             'active': false
+        },
+        'default_plugins': {
+            'web' : false
         }
     };
 
     const settings = Hoek.applyToDefaults(defaults, options);
     const seneca = Seneca(settings);
+
 
     server.decorate('server', 'seneca', seneca);
     server.decorate('server', 'action', internals.action(server));
@@ -40,10 +44,9 @@ exports.register = function (server, options, next) {
     server.handler('act', internals.handlers.act);
     server.handler('compose', internals.handlers.compose);
 
-    if (settings.web_plugin){
-        seneca.use(settings.web_plugin)
-    }
-    seneca.export( 'web' )(server, options, next, 'hapi')
+    // server.dependency('vision');
+
+    return next();
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,15 +23,11 @@ exports.register = function (server, options, next) {
         'log': 'silent',
         'actcache': {
             'active': false
-        },
-        'default_plugins': {
-            'web' : false
         }
     };
 
     const settings = Hoek.applyToDefaults(defaults, options);
     const seneca = Seneca(settings);
-
 
     server.decorate('server', 'seneca', seneca);
     server.decorate('server', 'action', internals.action(server));
@@ -44,9 +40,10 @@ exports.register = function (server, options, next) {
     server.handler('act', internals.handlers.act);
     server.handler('compose', internals.handlers.compose);
 
-    // server.dependency('vision');
-
-    return next();
+    if (settings.web_plugin){
+        seneca.use(settings.web_plugin)
+    }
+    seneca.export( 'web' )(server, options, next, 'hapi')
 };
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -384,14 +384,14 @@ describe('Request', () => {
 
             const handler = function (request, reply) {
 
-                return reply(request.seneca);
+                return reply(request.seneca.fixedargs.req$.url.path);
             };
 
             server.route({ method: 'GET', path: '/', handler: handler });
 
             server.inject('/', (res) => {
 
-                expect(res.result.fixedargs.req$.url).to.equal('/');
+                expect(res.result).to.equal('/');
                 done();
             });
         });

--- a/test/payload.test.js
+++ b/test/payload.test.js
@@ -1,0 +1,79 @@
+'use strict';
+
+// Load modules
+
+const Code = require('code');
+const Hapi = require('hapi');
+const Lab = require('lab');
+const Chairo = require('../');
+
+// Declare internals
+
+const internals = {};
+
+
+// Test shortcuts
+
+const lab = exports.lab = Lab.script();
+const describe = lab.describe;
+const it = lab.it;
+const expect = Code.expect;
+
+
+process.setMaxListeners(0);             // Remove warning caused by creating multiple framework instances
+
+
+describe('Handlers', () => {
+
+    it('can access payload in seneca action', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register([{ register: Chairo }, require('vision')], (err) => {
+
+            expect(err).to.not.exist();
+
+            server.seneca.add( { get: 'request' }, (message, next) => {
+
+                expect(message.req$.payload).to.deep.equal({ some: 'data', another: 'data' });
+                return next(null, { id: 1 });
+            });
+
+            server.route({ method: 'POST', path: '/', handler: { act: { get: 'request' } } });
+
+            server.inject( { method: 'POST', url: '/', payload: { some: 'data', another: 'data' } }, (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.result).to.deep.equal({ id: 1 });
+                done();
+            });
+        });
+    });
+
+
+    it('can access query parameters in seneca action', (done) => {
+
+        const server = new Hapi.Server();
+        server.connection();
+        server.register([{ register: Chairo }, require('vision')], (err) => {
+
+            expect(err).to.not.exist();
+
+            server.seneca.add( { verify: 'request' }, (message, next) => {
+
+                expect(message.req$.query).to.deep.equal({ some: 'action' });
+                return next(null, { id: 1 });
+            });
+
+            server.route({ method: 'GET', path: '/route', handler: { act: { verify: 'request' } } });
+
+            server.inject( { method: 'GET', url: '/route?some=action' }, (res) => {
+
+                expect(res.statusCode).to.equal(200);
+                expect(res.result).to.deep.equal({ id: 1 });
+                done();
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
request.raw.req contains the original request, however the request object contains parsed payload/query/authentication and other information.