### PR TITLE
Compose enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ the all web plugins set `web` to `false`.
 
 
 ```js
-var Chairo = require('chairo');
-var Hapi = require('hapi');
+const Chairo = require('chairo');
+const Hapi = require('hapi');
 
-var server = new Hapi.Server();
+const server = new Hapi.Server();
 server.connection();
 
 // Register plugin
@@ -40,7 +40,7 @@ server.register({ register: Chairo }, function (err) {
 
 	// Add a Seneca action
 
-    var id = 0;
+    let id = 0;
     server.seneca.add({ generate: 'id' }, function (message, next) {
 
         return next(null, { id: ++id });
@@ -90,10 +90,10 @@ Maps a **Seneca** action pattern to a **hapi**
     - `generateKey` - method generating custom cache key (same as the name used in `server.method()`).
 
 ```js
-var Chairo = require('chairo');
-var Hapi = require('hapi');
+const Chairo = require('chairo');
+const Hapi = require('hapi');
 
-var server = new Hapi.Server();
+const server = new Hapi.Server();
 server.connection();
 server.register(Chairo, function (err) {
 
@@ -154,10 +154,10 @@ Sends back a handler response using the result of a **Seneca** action where:
 - `pattern` - the **Seneca** action called to generate the response.
 
 ```js
-var Chairo = require('chairo');
-var Hapi = require('hapi');
+const Chairo = require('chairo');
+const Hapi = require('hapi');
 
-var server = new Hapi.Server();
+const server = new Hapi.Server();
 server.connection();
 server.register(Chairo, function (err) {
 
@@ -199,18 +199,20 @@ server.route({
 Renders a template view using the provided template and context where:
 - `template` - the view engine template (same as the name used in
   [`reply.view()`](https://github.com/hapijs/hapi/blob/master/API.md#replyviewtemplate-context-options)).
-- `context` - the context object used to render the template where each top level key with a `$`
-  suffix is assigned the corresponding **Seneca** action matching the key's value pattern.
+- `context` - the context object used to render the template. `Chairo` provides a special key `$resolve` where you can map context variables to **Seneca** actions matching they key's value pattern. Each of the service mapped to keys is resolved and resultant key value maps are copied at context root before redering the template.
 - `options` - optionals settings passed to `reply.view()`.
 
-```js
-var Chairo = require('chairo');
-var Handlebars = require('handlebars');
-var Hapi = require('hapi');
+It requires `vision` plugin to be registered with Hapi.
 
-var server = new Hapi.Server();
+```js
+const Chairo = require('chairo');
+const Handlebars = require('handlebars');
+const Vision = require('vision');
+const Hapi = require('hapi');
+
+const server = new Hapi.Server();
 server.connection();
-server.register(Chairo, function (err) {
+server.register([{ register: Chairo }, Vision], function (err) {
 
 	// set up a few Seneca actions
 
@@ -241,8 +243,10 @@ server.register(Chairo, function (err) {
 			// Setup context with both Seneca actions and simple keys
 
             var context = {
-                today$: 'lookup:date',							// Using string pattern
-                user$: { load: 'user', name: 'john' },			// Using object pattern
+                $resolve: {
+                    today: 'lookup:date',							// Using string pattern
+                    user: { load: 'user', name: 'john' }			// Using object pattern
+                },
                 general: {
                     message: 'hello!'
                 }
@@ -260,8 +264,8 @@ Using the template `./templates/example.html`:
 
 ```html
 <div>
-    <h1>{{today$.date}}</h1>
-    <h2>{{user$.name}}</h2>
+    <h1>{{today.date}}</h1>
+    <h2>{{user.name}}</h2>
     <h3>{{general.message}}</h3>
 </div>
 ```
@@ -276,8 +280,10 @@ server.route({
         compose: {
             template: 'example',
             context: {
-                today$: 'lookup:date',
-                user$: { load: 'user', name: 'john' },
+                $resolve: {
+                    today: 'lookup:date',
+                    user: { load: 'user', name: 'john' }
+                },
                 general: {
                     message: 'hello!'
                 }

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// Load Modules
+
+const Jsonic = require('jsonic');
+const Hoek = require('hoek');
+
+// Internals
+
+const internals = {};
+
+exports.apply = function (type, options) {
+
+    return Hoek.applyToDefaults(internals[type], options);
+};
+
+internals.seneca = {
+    log: 'silent',
+    actcache: {
+        active: false
+    },
+    default_plugins: {
+        basic: false,
+        web: false,
+        cluster: false,
+        'mem-store': false,
+        repl: false,
+        transport: false
+    },
+    web: false
+};
+
+internals.cache = {
+    generateKey: function (additions) {
+
+        if (!additions) {
+            return '{}';
+        }
+
+        if (typeof additions === 'string') {
+            additions = Jsonic(additions);
+        }
+
+        const keys = Object.keys(additions);
+        let result = '';
+        for (let i = 0; i < keys.length; ++i) {
+            const key = keys[i];
+            const value = additions[key];
+
+            if (typeof value === 'object') {
+                return null;
+            }
+
+            if (i) {
+                result = result + ',';
+            }
+
+            result = result + encodeURIComponent(key) + ':' + encodeURIComponent(value.toString());
+        }
+        return result;
+    }
+};

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -9,9 +9,14 @@ const Hoek = require('hoek');
 
 const internals = {};
 
-exports.apply = function (type, options) {
+exports.seneca = function (options) {
 
-    return Hoek.applyToDefaults(internals[type], options);
+    return Hoek.applyToDefaults(internals.seneca, options);
+};
+
+exports.cache = function (options) {
+
+    return Hoek.applyToDefaults(internals.cache, options);
 };
 
 internals.seneca = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ const internals = {
 
 exports.register = function (server, options, next) {
 
-    const settings = Defaults.apply('seneca', options);
+    const settings = Defaults.seneca(options);
     const seneca = Seneca(settings);
 
     if (typeof settings.web === 'function') {
@@ -62,7 +62,7 @@ internals.action = function (server) {
 
     return function (name, pattern, options) {
 
-        Schema.apply('action', options);     // Allow only cache option
+        Schema.action(options, 'Invalid Action Schema');     // Allow only cache option
 
         if (typeof pattern === 'string') {
             pattern = Jsonic(pattern);
@@ -85,7 +85,7 @@ internals.action = function (server) {
         if (options &&
             options.cache) {
 
-            const settings = Defaults.apply('cache', options);
+            const settings = Defaults.cache(options);
 
             return server.method(name, method, settings);
         }
@@ -134,7 +134,6 @@ internals.replies.compose = function (template, context, options) {
             tpl[action] = 'result';
             Hoek.merge(composed, Hoek.transform(source, tpl));
 
-            // composed[action] = result;
             return next();
         });
     };
@@ -171,7 +170,7 @@ internals.handlers.act = function (route, options) {
 
 internals.handlers.compose = function (route, options) {
 
-    Schema.apply('compose', options, 'Invalid compose handler options (' + route.path + ')');
+    Schema.compose(options, 'Invalid compose handler options (' + route.path + ')');
 
     return function (request, reply) {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,10 +4,11 @@
 
 const Hoek = require('hoek');
 const Items = require('items');
-const Joi = require('joi');
 const Jsonic = require('jsonic');
 const Seneca = require('seneca');
 const SenecaWeb = require('seneca-web');
+const Defaults = require('./defaults');
+const Schema = require('./schema');
 
 
 // Declare internals
@@ -20,17 +21,7 @@ const internals = {
 
 exports.register = function (server, options, next) {
 
-    const defaults = {
-        log: 'silent',
-        actcache: {
-            active: false
-        },
-        default_plugins: {
-            web: false
-        }
-    };
-
-    const settings = Hoek.applyToDefaults(defaults, options);
+    const settings = Defaults.apply('seneca', options);
     const seneca = Seneca(settings);
 
     if (typeof settings.web === 'function') {
@@ -67,14 +58,11 @@ exports.register.attributes = {
 };
 
 
-internals.actionSchema = Joi.object({ cache: Joi.object(), generateKey: Joi.func() });
-
-
 internals.action = function (server) {
 
     return function (name, pattern, options) {
 
-        Joi.assert(options, internals.actionSchema, 'Invalid action options');     // Allow only cache option
+        Schema.apply('action', options);     // Allow only cache option
 
         if (typeof pattern === 'string') {
             pattern = Jsonic(pattern);
@@ -97,38 +85,7 @@ internals.action = function (server) {
         if (options &&
             options.cache) {
 
-            const defaults = {
-                generateKey: function (additions) {
-
-                    if (!additions) {
-                        return '{}';
-                    }
-
-                    if (typeof additions === 'string') {
-                        additions = Jsonic(additions);
-                    }
-
-                    const keys = Object.keys(additions);
-                    let result = '';
-                    for (let i = 0; i < keys.length; ++i) {
-                        const key = keys[i];
-                        const value = additions[key];
-
-                        if (typeof value === 'object') {
-                            return null;                                    // Cannot cache complex criteria
-                        }
-
-                        if (i) {
-                            result = result + ',';
-                        }
-
-                        result = result + encodeURIComponent(key) + ':' + encodeURIComponent(value.toString());
-                    }
-
-                    return result;
-                }
-            };
-            const settings = Hoek.applyToDefaults(defaults, options);
+            const settings = Defaults.apply('cache', options);
 
             return server.method(name, method, settings);
         }
@@ -162,17 +119,22 @@ internals.replies.act = function (pattern) {
 internals.replies.compose = function (template, context, options) {
 
     const composed = Hoek.clone(context);
-    const actions = internals.collectActions(composed);
+    const actions = composed.$resolve ? Object.keys(composed.$resolve) : [];
     const seneca = this.request.seneca;
     const each = (action, next) => {
 
-        seneca.act(action.pattern, (err, result) => {
+        seneca.act(composed.$resolve[action], (err, result) => {
 
             if (err) {
                 return next(err);
             }
 
-            action.parent[action.key] = result;
+            const source = { result: result };
+            const tpl = {};
+            tpl[action] = 'result';
+            Hoek.merge(composed, Hoek.transform(source, tpl));
+
+            // composed[action] = result;
             return next();
         });
     };
@@ -186,30 +148,6 @@ internals.replies.compose = function (template, context, options) {
         return this.view(template, composed, options);
     });
 };
-
-
-internals.collectActions = function (context, results) {
-
-    results = results || [];
-
-    if (context) {
-        const keys = Object.keys(context);
-        for (let i = 0; i < keys.length; ++i) {
-            const key = keys[i];
-            const value = context[key];
-
-            if (key[key.length - 1] === '$') {
-                results.push({ parent: context, key: key, pattern: value });
-            }
-            else if (typeof value === 'object') {
-                internals.collectActions(value, results);
-            }
-        }
-    }
-
-    return results;
-};
-
 
 internals.handlers.act = function (route, options) {
 
@@ -231,16 +169,9 @@ internals.handlers.act = function (route, options) {
 };
 
 
-internals.composeSchema = Joi.object({
-    template: Joi.string().required(),
-    context: Joi.object().required(),
-    options: Joi.object()
-});
-
-
 internals.handlers.compose = function (route, options) {
 
-    Joi.assert(options, internals.composeSchema, 'Invalid compose handler options (' + route.path + ')');
+    Schema.apply('compose', options, 'Invalid compose handler options (' + route.path + ')');
 
     return function (request, reply) {
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,0 +1,28 @@
+'use strict';
+
+// Load Modules
+
+const Joi = require('joi');
+const Hoek = require('hoek');
+
+// Declare internals
+
+const internals = {};
+
+exports.apply = function (type, options, message) {
+
+    const result = Joi.validate(options, internals[type]);
+    Hoek.assert(!result.error, 'Invalid', type, 'options', message ? '(' + message + ')' : '', result.error && result.error.annotate());
+    return result.value;
+};
+
+internals.action =  Joi.object({
+    cache: Joi.object(),
+    generateKey: Joi.func()
+});
+
+internals.compose = Joi.object({
+    template: Joi.string().required(),
+    context: Joi.object().required(),
+    options: Joi.object()
+});

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -9,10 +9,17 @@ const Hoek = require('hoek');
 
 const internals = {};
 
-exports.apply = function (type, options, message) {
+exports.action = function (options, message) {
 
-    const result = Joi.validate(options, internals[type]);
-    Hoek.assert(!result.error, 'Invalid', type, 'options', message ? '(' + message + ')' : '', result.error && result.error.annotate());
+    const result = Joi.validate(options, internals.action);
+    Hoek.assert(!result.error, message);
+    return result.value;
+};
+
+exports.compose = function (options, message) {
+
+    const result = Joi.validate(options, internals.compose);
+    Hoek.assert(!result.error, message);
     return result.value;
 };
 

--- a/test/templates/test.html
+++ b/test/templates/test.html
@@ -1,5 +1,5 @@
 <div>
-    <h1>{{id$.id}}</h1>
-    <h2>{{user$.name}}</h2>
+    <h1>{{user.id.id}}</h1>
+    <h2>{{user.name.name}}</h2>
     <h3>{{general.message}}</h3>
 </div>


### PR DESCRIPTION
* Compose Enhancements:
   * `$resolve` for mapping services to context [(relevant code)](https://github.com/ooogway/chairo/blob/master/lib/index.js#L126-L139) 
   * Hoek templates for nested objects in context [(relevant code)](https://github.com/ooogway/chairo/blob/master/lib/index.js#L132-L135)
* Moved Defaults and Schema to separate files
* Default Seneca configuration: [(relevant code)](https://github.com/ooogway/chairo/blob/master/lib/defaults.js#L17-L31)
  * log: silent
  * actcache: disabled
  * default plugins: none
  * web: false
* README update

@geek: need your views on:

1. default seneca configuration: all tests pass with stripped down version of seneca. However, a cleaner way to enable plugins would be desirable, something like `enableWeb`: `boolean` OR `function`, or perhaps something like glue ? 
2. Hoek templates for $resolve object in compose: I haven't really thought thru the edge cases where this can go wrong
3. is it a good idea to register vision as a part of Chairo initialization ?