### PR TITLE
move vision to devDependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -42,8 +42,6 @@ exports.register = function (server, options, next) {
         seneca.use(settings.web);
     }
 
-    // server.dependency('vision');
-
     server.decorate('server', 'seneca', seneca);
     server.decorate('server', 'action', internals.action(server));
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "items": "2.0.x",
     "joi": "7.2.x",
     "jsonic": "0.2.x",
-    "seneca": "1.1.x",
-    "vision": "4.0.x"
+    "seneca": "1.1.x"
   },
   "peerDependencies": {
     "hapi": ">=11.x.x"
@@ -30,7 +29,8 @@
     "coveralls": "2.11.x",
     "handlebars": "4.0.x",
     "hapi": "13.0.x",
-    "lab": "8.2.x"
+    "lab": "8.2.x",
+    "vision": "4.0.x"
   },
   "scripts": {
     "test": "node node_modules/lab/bin/lab -a code -t 100 -L",


### PR DESCRIPTION
`vision` is not necessary for `chairo`. The users probably already have `vision` in their application's package.json.